### PR TITLE
Fix change length bug

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -32,3 +32,22 @@ The *latest* release can be installed by cloning the GitHub repository::
 The code above will clone the source code from GitHub repository, switch to the `develop` branch with the latest features,
 and install the library into the current Python (virtual) environment.
 
+
+Run tests
+^^^^^^^^^
+
+Running tests can be done as an optional step after installation. However, some additional
+libraries are required to run tests, hence we must do one more install, this time with `test` option enabled::
+
+  python3 -m pip install .[test]
+
+Then, running the tests is as simple as::
+
+  pytest
+
+This will run the unit and integration tests that do *not* require internet access. To run the "online" tests,
+we add ``--runonlin`` option to the command line invocation::
+
+  pytest --runonline
+
+That's all about testing!

--- a/src/genophenocorr/analysis/predicate/_all_predicates.py
+++ b/src/genophenocorr/analysis/predicate/_all_predicates.py
@@ -12,10 +12,10 @@ class HPOPresentPredicate(PolyPredicate[hpotk.TermId]):
                                name='Observed',
                                description="""
                                The sample *is* annotated with the tested phenotype feature `q`.
-                               
+
                                This is either because the sample is annotated with `q` (exact match),
                                or because one of sample's annotations is a descendant `q` (annotation propagation).
-                               For instance, we tested for a Seizure and the sample *had* a Clonic seizure 
+                               For instance, we tested for a Seizure and the sample *had* a Clonic seizure
                                (a descendant of Seizure).
                                """)
 
@@ -23,11 +23,11 @@ class HPOPresentPredicate(PolyPredicate[hpotk.TermId]):
                                    name='Not observed',
                                    description="""
                                    We are particular about the sample *not* having the tested feature `q`.
-                                   
+
                                    In other words, `q` was *excluded* in the sample or the sample is annotated with an excluded ancestor of `q`.
-                                   
-                                   For instance, we tested for a Clonic seizure and the sample did *not* have any Seizure, which implies 
-                                   *not* Clonic seizure.  
+
+                                   For instance, we tested for a Clonic seizure and the sample did *not* have any Seizure, which implies
+                                   *not* Clonic seizure.
                                    """)
 
     NOT_MEASURED = PatientCategory(cat_id=2,
@@ -36,7 +36,7 @@ class HPOPresentPredicate(PolyPredicate[hpotk.TermId]):
                                    We do not know if the sample has or has not the tested feature.
                                    """)
 
-    def __init__(self, 
+    def __init__(self,
                  hpo: hpotk.MinimalOntology) -> None:
         self._hpo = hpotk.util.validate_instance(hpo, hpotk.MinimalOntology, 'hpo')
 
@@ -69,13 +69,13 @@ class HPOPresentPredicate(PolyPredicate[hpotk.TermId]):
 HETEROZYGOUS = PatientCategory(cat_id=0,
                             name='Heterozygous',
                             description="""
-                            This sample has the tested attribute on one allele. 
+                            This sample has the tested attribute on one allele.
                             """)
 
 HOMOZYGOUS = PatientCategory(cat_id=1,
                                 name='Homozygous',
                                 description="""
-                                This sample has the tested attribute on both alleles. 
+                                This sample has the tested attribute on both alleles.
                                 """)
 
 NO_VARIANT = PatientCategory(cat_id=2,
@@ -87,7 +87,7 @@ NO_VARIANT = PatientCategory(cat_id=2,
 
 
 class VariantEffectPredicate(PolyPredicate[VariantEffect]):
-    
+
     def __init__(self, transcript:str) -> None:
         self._transcript = transcript
 

--- a/src/genophenocorr/preprocessing/__init__.py
+++ b/src/genophenocorr/preprocessing/__init__.py
@@ -1,7 +1,7 @@
 from ._api import VariantCoordinateFinder, FunctionalAnnotator, ProteinMetadataService
-from ._config import configure_caching_patient_creator
+from ._config import configure_caching_patient_creator, configure_patient_creator
 from ._patient import PatientCreator
-from ._phenopacket import PhenopacketVariantCoordinateFinder, PhenopacketPatientCreator, load_phenopacket_folder
+from ._phenopacket import PhenopacketVariantCoordinateFinder, PhenopacketPatientCreator, load_phenopacket_folder, load_phenopacket
 from ._phenotype import PhenotypeCreator, PhenotypeValidationException
 from ._protein import ProteinAnnotationCache, ProtCachingFunctionalAnnotator
 from ._uniprot import UniprotProteinMetadataService
@@ -11,10 +11,10 @@ from ._vep import VepFunctionalAnnotator
 __all__ = [
     'VariantCoordinateFinder', 'FunctionalAnnotator', 'ProteinMetadataService',
     'PatientCreator',
-    'PhenopacketVariantCoordinateFinder', 'PhenopacketPatientCreator', 'load_phenopacket_folder',
+    'PhenopacketVariantCoordinateFinder', 'PhenopacketPatientCreator', 'load_phenopacket_folder', 'load_phenopacket',
     'PhenotypeCreator', 'PhenotypeValidationException',
     'ProteinAnnotationCache', 'ProtCachingFunctionalAnnotator',
     'UniprotProteinMetadataService',
     'VepFunctionalAnnotator', 'VariantAnnotationCache', 'VarCachingFunctionalAnnotator',
-    'configure_caching_patient_creator'
+    'configure_caching_patient_creator', 'configure_patient_creator'
 ]

--- a/src/genophenocorr/preprocessing/_config.py
+++ b/src/genophenocorr/preprocessing/_config.py
@@ -12,6 +12,7 @@ from ._protein import ProteinAnnotationCache, ProtCachingFunctionalAnnotator
 from ._uniprot import UniprotProteinMetadataService
 from ._variant import VarCachingFunctionalAnnotator, VariantAnnotationCache
 from ._vep import VepFunctionalAnnotator
+from ._vv import VVHgvsVariantCoordinateFinder
 
 
 def configure_caching_patient_creator(hpo: hpotk.MinimalOntology,
@@ -48,7 +49,8 @@ def configure_caching_patient_creator(hpo: hpotk.MinimalOntology,
 
     phenotype_creator = _setup_phenotype_creator(hpo, validation_runner)
     functional_annotator = _configure_functional_annotator(cache_dir, variant_fallback, protein_fallback)
-    return PhenopacketPatientCreator(build, phenotype_creator, functional_annotator)
+    hgvs_annotator = VVHgvsVariantCoordinateFinder(build)
+    return PhenopacketPatientCreator(build, phenotype_creator, functional_annotator, hgvs_annotator)
 
 
 def _setup_phenotype_creator(hpo: hpotk.MinimalOntology,

--- a/src/genophenocorr/preprocessing/_config.py
+++ b/src/genophenocorr/preprocessing/_config.py
@@ -3,11 +3,11 @@ import typing
 
 import hpotk
 
-from genophenocorr.model.genome import GRCh37, GRCh38
+from genophenocorr.model.genome import GRCh37, GRCh38, GenomeBuild
 
+from ._api import FunctionalAnnotator, ProteinMetadataService
 from ._phenotype import PhenotypeCreator
 from ._phenopacket import PhenopacketPatientCreator
-from ._api import FunctionalAnnotator
 from ._protein import ProteinAnnotationCache, ProtCachingFunctionalAnnotator
 from ._uniprot import UniprotProteinMetadataService
 from ._variant import VarCachingFunctionalAnnotator, VariantAnnotationCache
@@ -24,7 +24,7 @@ def configure_caching_patient_creator(hpo: hpotk.MinimalOntology,
     """
     A convenience function for configuring a caching :class:`genophenocorr.preprocessing.PhenopacketPatientCreator`.
 
-    To create the patient creator, we need hpo-toolkit's representation of HPO, the validator
+    To create the patient creator, we need hpo-toolkit's representation of HPO. Other options are optional.
 
     :param hpo: a HPO instance.
     :param genome_build: name of the genome build to use, choose from `{'GRCh37.p13', 'GRCh38.p13'}`.
@@ -40,17 +40,49 @@ def configure_caching_patient_creator(hpo: hpotk.MinimalOntology,
     if cache_dir is None:
         cache_dir = os.path.join(os.getcwd(), '.genophenocorr_cache')
 
-    if genome_build == 'GRCh38.p13':
-        build = GRCh38
-    elif genome_build == 'GRCh37.p13':
-        build = GRCh37
-    else:
-        raise ValueError(f'Unknown build {genome_build}. Choose from [\'GRCh37.p13\', \'GRCh38.p13\']')
-
+    build = _configure_build(genome_build)
     phenotype_creator = _setup_phenotype_creator(hpo, validation_runner)
     functional_annotator = _configure_functional_annotator(cache_dir, variant_fallback, protein_fallback)
     hgvs_annotator = VVHgvsVariantCoordinateFinder(build)
     return PhenopacketPatientCreator(build, phenotype_creator, functional_annotator, hgvs_annotator)
+
+
+def configure_patient_creator(hpo: hpotk.MinimalOntology,
+                              genome_build: str = 'GRCh38.p13',
+                              validation_runner: typing.Optional[hpotk.validate.ValidationRunner] = None,
+                              variant_fallback: str = 'VEP',
+                              protein_fallback: str = 'UNIPROT') -> PhenopacketPatientCreator:
+    """
+    A convenience function for configuring a non-caching :class:`genophenocorr.preprocessing.PhenopacketPatientCreator`.
+
+    To create the patient creator, we need hpo-toolkit's representation of HPO. Other options are optional
+
+    :param hpo: a HPO instance.
+    :param genome_build: name of the genome build to use, choose from `{'GRCh37.p13', 'GRCh38.p13'}`.
+    :param validation_runner: an instance of the validation runner.
+     if the data should be cached in `.cache` folder in the current working directory.
+     In any case, the directory will be created if it does not exist (including non-existing parents).
+    :param variant_fallback: the fallback variant annotator to use if we cannot find the annotation locally.
+     Choose from ``{'VEP'}`` (just one fallback implementation is available at the moment).
+    :param protein_fallback: the fallback protein metadata annotator to use if we cannot find the annotation locally.
+     Choose from ``{'UNIPROT'}`` (just one fallback implementation is available at the moment).
+    """
+    build = _configure_build(genome_build)
+
+    phenotype_creator = _setup_phenotype_creator(hpo, validation_runner)
+    protein_metadata_service = _configure_fallback_protein_service(protein_fallback)
+    functional_annotator = _configure_fallback_functional(protein_metadata_service, variant_fallback)
+    hgvs_annotator = VVHgvsVariantCoordinateFinder(build)
+    return PhenopacketPatientCreator(build, phenotype_creator, functional_annotator, hgvs_annotator)
+
+
+def _configure_build(genome_build: str) -> GenomeBuild:
+    if genome_build == 'GRCh38.p13':
+        return GRCh38
+    elif genome_build == 'GRCh37.p13':
+        return GRCh37
+    else:
+        raise ValueError(f'Unknown build {genome_build}. Choose from [\'GRCh37.p13\', \'GRCh38.p13\']')
 
 
 def _setup_phenotype_creator(hpo: hpotk.MinimalOntology,
@@ -72,23 +104,17 @@ def _configure_functional_annotator(cache_dir: str,
                                     protein_fallback: str) -> FunctionalAnnotator:
     # (1) ProteinMetadataService
     # Setup fallback
-    if protein_fallback == 'UNIPROT':
-        fallback1 = UniprotProteinMetadataService()
-    else:
-        raise ValueError(f'Unknown protein fallback annotator type {protein_fallback}')
+    protein_fallback = _configure_fallback_protein_service(protein_fallback)
     # Setup protein metadata cache
     prot_cache_dir = os.path.join(cache_dir, 'protein_cache')
     os.makedirs(prot_cache_dir, exist_ok=True)
     prot_cache = ProteinAnnotationCache(prot_cache_dir)
     # Assemble the final protein metadata service
-    protein_metadata_service = ProtCachingFunctionalAnnotator(prot_cache, fallback1)
+    protein_metadata_service = ProtCachingFunctionalAnnotator(prot_cache, protein_fallback)
 
     # (2) FunctionalAnnotator
     # Setup fallback
-    if variant_fallback == 'VEP':
-        fallback = VepFunctionalAnnotator(protein_metadata_service)
-    else:
-        raise ValueError(f'Unknown variant fallback annotator type {variant_fallback}')
+    fallback = _configure_fallback_functional(protein_metadata_service, variant_fallback)
 
     # Setup variant cache
     var_cache_dir = os.path.join(cache_dir, 'variant_cache')
@@ -97,5 +123,22 @@ def _configure_functional_annotator(cache_dir: str,
 
     # Assemble the final functional annotator
     return VarCachingFunctionalAnnotator(var_cache, fallback)
+
+
+def _configure_fallback_protein_service(protein_fallback: str) -> ProteinMetadataService:
+    if protein_fallback == 'UNIPROT':
+        fallback1 = UniprotProteinMetadataService()
+    else:
+        raise ValueError(f'Unknown protein fallback annotator type {protein_fallback}')
+    return fallback1
+
+
+def _configure_fallback_functional(protein_metadata_service: ProteinMetadataService,
+                                   variant_fallback: str) -> FunctionalAnnotator:
+    if variant_fallback == 'VEP':
+        fallback = VepFunctionalAnnotator(protein_metadata_service)
+    else:
+        raise ValueError(f'Unknown variant fallback annotator type {variant_fallback}')
+    return fallback
 
 

--- a/src/genophenocorr/preprocessing/_phenopacket.py
+++ b/src/genophenocorr/preprocessing/_phenopacket.py
@@ -255,11 +255,16 @@ def _load_phenopacket_dir(pp_dir: str) -> typing.Sequence[Phenopacket]:
     for patient_file in os.listdir(pp_dir):
         if patient_file.endswith('.json'):
             phenopacket_path = os.path.join(pp_dir, patient_file)
-            pp = _load_phenopacket(phenopacket_path)
+            pp = load_phenopacket(phenopacket_path)
             patients.append(pp)
     return patients
 
 
-def _load_phenopacket(phenopacket_path: str) -> Phenopacket:
+def load_phenopacket(phenopacket_path: str) -> Phenopacket:
+    """
+    Load phenopacket JSON file.
+
+    :param phenopacket_path: a `str` pointing to phenopacket JSON file.
+    """
     with open(phenopacket_path) as f:
         return Parse(f.read(), Phenopacket())

--- a/src/genophenocorr/preprocessing/_phenopacket.py
+++ b/src/genophenocorr/preprocessing/_phenopacket.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import os
 import typing
 
@@ -20,15 +19,19 @@ from ._api import VariantCoordinateFinder, FunctionalAnnotator
 
 
 class PhenopacketVariantCoordinateFinder(VariantCoordinateFinder[GenomicInterpretation]):
-    """A class that creates VariantCoordinates from a Phenopacket
-
-    Methods:
-        find_coordinates(item:GenomicInterpretation): Creates VariantCoordinates from the data in a given Phenopacket
     """
-    def __init__(self, build: GenomeBuild):
-        """Constructs all necessary attributes for a PhenopacketVariantCoordinateFinder object"""
+    `PhenopacketVariantCoordinateFinder` figures out :class:`genophenocorr.model.VariantCoordinates`
+    and :class:`genophenocorr.model.Genotype` from `GenomicInterpretation` element of Phenopacket Schema.
+
+    :param build: genome build to use in `VariantCoordinates
+    :param hgvs_coordinate_finder: the coordinate finder to use for parsing HGVS expressions
+    """
+    def __init__(self, build: GenomeBuild,
+                 hgvs_coordinate_finder: VariantCoordinateFinder[str]):
         self._logger = logging.getLogger(__name__)
-        self._build = build
+        self._build = hpotk.util.validate_instance(build, GenomeBuild, 'build')
+        self._hgvs_finder = hpotk.util.validate_instance(hgvs_coordinate_finder, VariantCoordinateFinder,
+                                                         'hgvs_coordinate_finder')
 
     def find_coordinates(self, item: GenomicInterpretation) -> typing.Tuple[VariantCoordinates, Genotype]:
         """Creates a VariantCoordinates object from the data in a given Phenopacket
@@ -40,37 +43,54 @@ class PhenopacketVariantCoordinateFinder(VariantCoordinateFinder[GenomicInterpre
         """
         if not isinstance(item, GenomicInterpretation):
             raise ValueError(f"item must be a Phenopacket GenomicInterpretation but was type {type(item)}")
+
         variant_descriptor = item.variant_interpretation.variation_descriptor
-        if len(variant_descriptor.vcf_record.chrom) == 0 and len(
-                variant_descriptor.variation.copy_number.allele.sequence_location.sequence_id) != 0:
+
+        vc = None
+        if variant_descriptor.vcf_record.IsInitialized():
+            # We have a VCF record.
+            contig = self._build.contig_by_name(variant_descriptor.vcf_record.chrom)
+            start = int(variant_descriptor.vcf_record.pos) - 1
+            ref = variant_descriptor.vcf_record.ref
+            alt = variant_descriptor.vcf_record.alt
+            end = start + len(ref)
+            change_length = end - start
+
+            region = GenomicRegion(contig, start, end, Strand.POSITIVE)
+            vc = VariantCoordinates(region, ref, alt, change_length)
+        elif variant_descriptor.variation.IsInitialized():
+            # We have a CNV.
+            seq_location = variant_descriptor.variation.copy_number.allele.sequence_location
+            refseq_contig_name = seq_location.sequence_id.split(':')[1]
+            contig = self._build.contig_by_name(refseq_contig_name)
+
+            # Assuming SV coordinates are 1-based (VCF style),
+            # so we subtract 1 to transform to 0-based coordinate system
+            start = int(seq_location.sequence_interval.start_number.value) - 1
+            end = int(seq_location.sequence_interval.end_number.value)
             ref = 'N'
-            start = int(
-                variant_descriptor.variation.copy_number.allele.sequence_location.sequence_interval.start_number.value)
-            end = int(
-                variant_descriptor.variation.copy_number.allele.sequence_location.sequence_interval.end_number.value)
             number = int(variant_descriptor.variation.copy_number.number.value)
             if number > 2:
                 alt = '<DUP>'
             else:
                 alt = '<DEL>'
-            refseq_contig_name = variant_descriptor.variation.copy_number.allele.sequence_location.sequence_id.split(':')[1]
-            contig = self._build.contig_by_name(refseq_contig_name)
-        elif len(variant_descriptor.vcf_record.chrom) != 0 and len(
-                variant_descriptor.variation.copy_number.allele.sequence_location.sequence_id) == 0:
-            ref = variant_descriptor.vcf_record.ref
-            alt = variant_descriptor.vcf_record.alt
-            start = int(variant_descriptor.vcf_record.pos) - 1
-            end = int(variant_descriptor.vcf_record.pos) + abs(len(alt) - len(ref))
-            contig = self._build.contig_by_name(variant_descriptor.vcf_record.chrom[3:])
+            change_length = end - start
+
+            region = GenomicRegion(contig, start, end, Strand.POSITIVE)
+            vc = VariantCoordinates(region, ref, alt, change_length)
+        elif len(variant_descriptor.expressions) > 0:
+            # We have some expressions. Let's try to find the 1st expression with `hgvs.c` syntax.
+            for expression in variant_descriptor.expressions:
+                if expression.syntax == 'hgvs.c':
+                    vc = self._hgvs_finder.find_coordinates(expression.value)
+                    break
         else:
-            raise ValueError('Expected a VCF record or a VRS CNV but did not find one')
+            # No way we can get something from this `GenomicInterpretation`!
+            raise ValueError('Expected a VCF record, a VRS CNV, or an expression with `hgvs.c` '
+                             'but did not find one')
+
+        # Last, parse genotype.
         genotype = variant_descriptor.allelic_state.label
-
-        if any(field is None for field in (contig, ref, alt, genotype)):
-            raise ValueError(f'Cannot determine variant coordinate from genomic interpretation {item}')
-        region = GenomicRegion(contig, start, end, Strand.POSITIVE)
-
-        vc = VariantCoordinates(region, ref, alt, len(alt) - len(ref))
         gt = self._map_geno_genotype_label(genotype)
 
         return vc, gt
@@ -91,25 +111,17 @@ class PhenopacketVariantCoordinateFinder(VariantCoordinateFinder[GenomicInterpre
 
 
 class PhenopacketPatientCreator(PatientCreator[Phenopacket]):
-    """A class that creates a Patient object
-
-    Methods:
-        create_patient(item:Phenopacket): Creates a Patient from the data in a given Phenopacket
+    """
+    `PhenopacketPatientCreator` transforms `Phenopacket` into :class:`genophenocorr.model.Patient`.
     """
 
     def __init__(self, build: GenomeBuild,
                  phenotype_creator: PhenotypeCreator,
-                 var_func_ann: FunctionalAnnotator):
-        """Constructs all necessary attributes for a PhenopacketPatientCreator object
-
-        Args:
-            build (GenomeBuild): A genome build to use to load variant coordinates.
-            phenotype_creator (PhenotypeCreator): A PhenotypeCreator object for Phenotype creation
-            var_func_ann (FunctionalAnnotator): A FunctionalAnnotator object for Variant creation
-        """
+                 var_func_ann: FunctionalAnnotator,
+                 hgvs_coordinate_finder: VariantCoordinateFinder[str]):
         self._logger = logging.getLogger(__name__)
         # Violates DI, but it is specific to this class, so I'll leave it "as is".
-        self._coord_finder = PhenopacketVariantCoordinateFinder(build)
+        self._coord_finder = PhenopacketVariantCoordinateFinder(build, hgvs_coordinate_finder)
         self._phenotype_creator = hpotk.util.validate_instance(phenotype_creator, PhenotypeCreator, 'phenotype_creator')
         self._func_ann = hpotk.util.validate_instance(var_func_ann, FunctionalAnnotator, 'var_func_ann')
 

--- a/src/genophenocorr/preprocessing/_test_variant.py
+++ b/src/genophenocorr/preprocessing/_test_variant.py
@@ -69,6 +69,7 @@ def caching_annotator(variant_annotator, tmp_path):
     vac = VariantAnnotationCache(tmp_path)
     return VarCachingFunctionalAnnotator(vac, variant_annotator)
 
+@pytest.mark.online
 def test_caching_full_circle(caching_annotator, pp_vc_finder, variant_annotator):
     fname = resource_filename(__name__, 'test_data/missense_test.json')
     gi = read_genomic_interpretation_json(fname)

--- a/src/genophenocorr/preprocessing/_test_vep.py
+++ b/src/genophenocorr/preprocessing/_test_vep.py
@@ -59,6 +59,7 @@ def test_verify_start_end_coordinates(contig_name, start, end, ref, alt, chlen, 
     assert out == expected
 
 
+@pytest.mark.online  # Online due to using real Uniprot service
 class TestVepFunctionalAnnotator:
     TEST_DATA_DIR = resource_filename(__name__, os.path.join('test_data', 'vep_response'))
 

--- a/src/genophenocorr/preprocessing/_test_vv.py
+++ b/src/genophenocorr/preprocessing/_test_vv.py
@@ -90,6 +90,11 @@ class TestVVHgvsVariantCoordinateFinder:
         assert vc.alt == 'TAGC'
         assert vc.change_length == 3
 
+    @pytest.mark.skip('Online tests are disabled by default')
+    def test_find_coordinates(self, coordinate_finder: VVHgvsVariantCoordinateFinder):
+        vc = coordinate_finder.find_coordinates('NM_013275.6:c.7407C>G')
+        print(vc)
+
 
 def load_response_json(path: str):
     with open(path) as fh:

--- a/src/genophenocorr/preprocessing/_vep.py
+++ b/src/genophenocorr/preprocessing/_vep.py
@@ -1,9 +1,7 @@
 # A module with classes that interact with Ensembl's REST API to fetch required data.
 import logging
-import re
 import typing
 
-import hpotk
 import requests
 
 from genophenocorr.model import VariantCoordinates, TranscriptAnnotation, VariantEffect
@@ -40,7 +38,6 @@ def verify_start_end_coordinates(vc: VariantCoordinates):
         if len(vc.ref) == 1 and len(vc.alt) != 1:
             # INS/DUP
             start = start + 1  # we must "trim"
-            end = end - 1
             alt = vc.alt[1:]
             # 100 AC AGT
             # MNV
@@ -68,8 +65,7 @@ class VepFunctionalAnnotator(FunctionalAnnotator):
                     '&transcript_version=1&variant_class=1'
         self._include_computational_txs = include_computational_txs
 
-    def annotate(self, variant_coordinates: VariantCoordinates) -> typing.Sequence[
-        TranscriptAnnotation]:
+    def annotate(self, variant_coordinates: VariantCoordinates) -> typing.Sequence[TranscriptAnnotation]:
         """Perform functional annotation using Variant Effect Predictor (VEP) REST API.
 
         Args:

--- a/src/genophenocorr/preprocessing/_vv.py
+++ b/src/genophenocorr/preprocessing/_vv.py
@@ -21,7 +21,7 @@ class VVHgvsVariantCoordinateFinder(VariantCoordinateFinder[str]):
     :param timeout: the REST API request timeout
     """
 
-    def __init__(self, genome_build: GenomeBuild, timeout: int = 10):
+    def __init__(self, genome_build: GenomeBuild, timeout: int = 30):
         self._build = hpotk.util.validate_instance(genome_build, GenomeBuild, 'genome_build')
         self._timeout = timeout
         self._url = 'https://rest.variantvalidator.org/VariantValidator/variantvalidator/%s/%s/%s'

--- a/src/genophenocorr/preprocessing/test_data/CVDel_test.json
+++ b/src/genophenocorr/preprocessing/test_data/CVDel_test.json
@@ -1,41 +1,41 @@
-            {
-                "subjectOrBiosampleId": "Gnazzo, 2020_P29",
-                "interpretationStatus": "CAUSATIVE",
-                "variantInterpretation": {
-                "variationDescriptor": {
-                    "variation": {
-                    "copyNumber": {
-                        "allele": {
-                        "sequenceLocation": {
-                            "sequenceId": "refseq:NC_000016.10",
-                            "sequenceInterval": {
-                            "startNumber": {
-                                "value": "89217281"
-                            },
-                            "endNumber": {
-                                "value": "89506042"
-                            }
-                            }
-                        }
-                        },
-                        "number": {
-                        "value": "1"
-                        }
-                    }
-                    },
-                    "description": "16q24.3(89217281_89506042)x1",
-                    "geneContext": {
-                    "valueId": "HGNC:21316",
-                    "symbol": "ANKRD11"
-                    },
-                    "structuralType": {
-                    "id": "SO:1000029",
-                    "label": "chromosomal_deletion"
-                    },
-                    "allelicState": {
-                    "id": "GENO:0000135",
-                    "label": "heterozygous"
-                    }
+{
+  "subjectOrBiosampleId": "Gnazzo, 2020_P29",
+  "interpretationStatus": "CAUSATIVE",
+  "variantInterpretation": {
+    "variationDescriptor": {
+      "variation": {
+        "copyNumber": {
+          "allele": {
+            "sequenceLocation": {
+              "sequenceId": "refseq:NC_000016.10",
+              "sequenceInterval": {
+                "startNumber": {
+                  "value": "89217281"
+                },
+                "endNumber": {
+                  "value": "89506042"
                 }
-                }
+              }
             }
+          },
+          "number": {
+            "value": "1"
+          }
+        }
+      },
+      "description": "16q24.3(89217281_89506042)x1",
+      "geneContext": {
+        "valueId": "HGNC:21316",
+        "symbol": "ANKRD11"
+      },
+      "structuralType": {
+        "id": "SO:1000029",
+        "label": "chromosomal_deletion"
+      },
+      "allelicState": {
+        "id": "GENO:0000135",
+        "label": "heterozygous"
+      }
+    }
+  }
+}

--- a/src/genophenocorr/preprocessing/test_data/CVDup_test.json
+++ b/src/genophenocorr/preprocessing/test_data/CVDup_test.json
@@ -1,42 +1,41 @@
-
-            {
-                "subjectOrBiosampleId": "Crippa2015_P3",
-                "interpretationStatus": "CAUSATIVE",
-                "variantInterpretation": {
-                "variationDescriptor": {
-                    "variation": {
-                    "copyNumber": {
-                        "allele": {
-                        "sequenceLocation": {
-                            "sequenceId": "refseq:NC_000016.10",
-                            "sequenceInterval": {
-                            "startNumber": {
-                                "value": "89284523"
-                            },
-                            "endNumber": {
-                                "value": "89373231"
-                            }
-                            }
-                        }
-                        },
-                        "number": {
-                        "value": "3"
-                        }
-                    }
-                    },
-                    "description": "16q24.3(89284523_89373231)x3",
-                    "geneContext": {
-                    "valueId": "HGNC:21316",
-                    "symbol": "ANKRD11"
-                    },
-                    "structuralType": {
-                    "id": "SO:1000029",
-                    "label": "chromosomal_deletion"
-                    },
-                    "allelicState": {
-                    "id": "GENO:0000135",
-                    "label": "heterozygous"
-                    }
+{
+  "subjectOrBiosampleId": "Crippa2015_P3",
+  "interpretationStatus": "CAUSATIVE",
+  "variantInterpretation": {
+    "variationDescriptor": {
+      "variation": {
+        "copyNumber": {
+          "allele": {
+            "sequenceLocation": {
+              "sequenceId": "refseq:NC_000016.10",
+              "sequenceInterval": {
+                "startNumber": {
+                  "value": "89284523"
+                },
+                "endNumber": {
+                  "value": "89373231"
                 }
-                }
+              }
             }
+          },
+          "number": {
+            "value": "3"
+          }
+        }
+      },
+      "description": "16q24.3(89284523_89373231)x3",
+      "geneContext": {
+        "valueId": "HGNC:21316",
+        "symbol": "ANKRD11"
+      },
+      "structuralType": {
+        "id": "SO:1000029",
+        "label": "chromosomal_deletion"
+      },
+      "allelicState": {
+        "id": "GENO:0000135",
+        "label": "heterozygous"
+      }
+    }
+  }
+}

--- a/src/genophenocorr/preprocessing/test_data/deletion_test.json
+++ b/src/genophenocorr/preprocessing/test_data/deletion_test.json
@@ -1,35 +1,34 @@
-
-            {
-                "subjectOrBiosampleId": "Bianchi, 2018",
-                "interpretationStatus": "CAUSATIVE",
-                "variantInterpretation": {
-                "variationDescriptor": {
-                    "geneContext": {
-                    "valueId": "HGNC:21316",
-                    "symbol": "ANKRD11"
-                    },
-                    "expressions": [
-                    {
-                        "syntax": "hgvs.c",
-                        "value": "NM_013275.6:c.2408_2412del"
-                    },
-                    {
-                        "syntax": "hgvs.g",
-                        "value": "NC_000016.10:g.89284131_89284135del"
-                    }
-                    ],
-                    "vcfRecord": {
-                    "genomeAssembly": "hg38",
-                    "chrom": "chr16",
-                    "pos": "89284129",
-                    "ref": "CTTTTT",
-                    "alt": "C"
-                    },
-                    "moleculeContext": "genomic",
-                    "allelicState": {
-                    "id": "GENO:0000135",
-                    "label": "heterozygous"
-                    }
-                }
-                }
-            }
+{
+  "subjectOrBiosampleId": "Bianchi, 2018",
+  "interpretationStatus": "CAUSATIVE",
+  "variantInterpretation": {
+    "variationDescriptor": {
+      "geneContext": {
+        "valueId": "HGNC:21316",
+        "symbol": "ANKRD11"
+      },
+      "expressions": [
+        {
+          "syntax": "hgvs.c",
+          "value": "NM_013275.6:c.2408_2412del"
+        },
+        {
+          "syntax": "hgvs.g",
+          "value": "NC_000016.10:g.89284131_89284135del"
+        }
+      ],
+      "vcfRecord": {
+        "genomeAssembly": "hg38",
+        "chrom": "chr16",
+        "pos": "89284129",
+        "ref": "CTTTTT",
+        "alt": "C"
+      },
+      "moleculeContext": "genomic",
+      "allelicState": {
+        "id": "GENO:0000135",
+        "label": "heterozygous"
+      }
+    }
+  }
+}

--- a/src/genophenocorr/preprocessing/test_data/delinsert_test.json
+++ b/src/genophenocorr/preprocessing/test_data/delinsert_test.json
@@ -1,35 +1,34 @@
-
-          {
-            "subjectOrBiosampleId": "KBG7",
-            "interpretationStatus": "CAUSATIVE",
-            "variantInterpretation": {
-              "variationDescriptor": {
-                "geneContext": {
-                  "valueId": "HGNC:21316",
-                  "symbol": "ANKRD11"
-                },
-                "expressions": [
-                  {
-                    "syntax": "hgvs.c",
-                    "value": "NM_013275.6:c.1940_1941delinsT"
-                  },
-                  {
-                    "syntax": "hgvs.g",
-                    "value": "NC_000016.10:g.89284601_89284602delinsA"
-                  }
-                ],
-                "vcfRecord": {
-                  "genomeAssembly": "hg38",
-                  "chrom": "chr16",
-                  "pos": "89284601",
-                  "ref": "GG",
-                  "alt": "A"
-                },
-                "moleculeContext": "genomic",
-                "allelicState": {
-                  "id": "GENO:0000135",
-                  "label": "heterozygous"
-                }
-              }
-            }
-          }
+{
+  "subjectOrBiosampleId": "KBG7",
+  "interpretationStatus": "CAUSATIVE",
+  "variantInterpretation": {
+    "variationDescriptor": {
+      "geneContext": {
+        "valueId": "HGNC:21316",
+        "symbol": "ANKRD11"
+      },
+      "expressions": [
+        {
+          "syntax": "hgvs.c",
+          "value": "NM_013275.6:c.1940_1941delinsT"
+        },
+        {
+          "syntax": "hgvs.g",
+          "value": "NC_000016.10:g.89284601_89284602delinsA"
+        }
+      ],
+      "vcfRecord": {
+        "genomeAssembly": "hg38",
+        "chrom": "chr16",
+        "pos": "89284601",
+        "ref": "GG",
+        "alt": "A"
+      },
+      "moleculeContext": "genomic",
+      "allelicState": {
+        "id": "GENO:0000135",
+        "label": "heterozygous"
+      }
+    }
+  }
+}

--- a/src/genophenocorr/preprocessing/test_data/duplication_test.json
+++ b/src/genophenocorr/preprocessing/test_data/duplication_test.json
@@ -1,35 +1,34 @@
-
-            {
-                "subjectOrBiosampleId": "KBG6",
-                "interpretationStatus": "CAUSATIVE",
-                "variantInterpretation": {
-                "variationDescriptor": {
-                    "geneContext": {
-                    "valueId": "HGNC:21316",
-                    "symbol": "ANKRD11"
-                    },
-                    "expressions": [
-                    {
-                        "syntax": "hgvs.c",
-                        "value": "NM_013275.6:c.6691dup"
-                    },
-                    {
-                        "syntax": "hgvs.g",
-                        "value": "NC_000016.10:g.89279853dup"
-                    }
-                    ],
-                    "vcfRecord": {
-                    "genomeAssembly": "hg38",
-                    "chrom": "chr16",
-                    "pos": "89279850",
-                    "ref": "G",
-                    "alt": "GC"
-                    },
-                    "moleculeContext": "genomic",
-                    "allelicState": {
-                    "id": "GENO:0000135",
-                    "label": "heterozygous"
-                    }
-                }
-                }
-            }
+{
+  "subjectOrBiosampleId": "KBG6",
+  "interpretationStatus": "CAUSATIVE",
+  "variantInterpretation": {
+    "variationDescriptor": {
+      "geneContext": {
+        "valueId": "HGNC:21316",
+        "symbol": "ANKRD11"
+      },
+      "expressions": [
+        {
+          "syntax": "hgvs.c",
+          "value": "NM_013275.6:c.6691dup"
+        },
+        {
+          "syntax": "hgvs.g",
+          "value": "NC_000016.10:g.89279853dup"
+        }
+      ],
+      "vcfRecord": {
+        "genomeAssembly": "hg38",
+        "chrom": "chr16",
+        "pos": "89279850",
+        "ref": "G",
+        "alt": "GC"
+      },
+      "moleculeContext": "genomic",
+      "allelicState": {
+        "id": "GENO:0000135",
+        "label": "heterozygous"
+      }
+    }
+  }
+}

--- a/src/genophenocorr/preprocessing/test_data/insertion_test.json
+++ b/src/genophenocorr/preprocessing/test_data/insertion_test.json
@@ -1,35 +1,34 @@
-
-            {
-                "subjectOrBiosampleId": "Gnazzo, 2020_P23",
-                "interpretationStatus": "CAUSATIVE",
-                "variantInterpretation": {
-                "variationDescriptor": {
-                    "geneContext": {
-                    "valueId": "HGNC:21316",
-                    "symbol": "ANKRD11"
-                    },
-                    "expressions": [
-                    {
-                        "syntax": "hgvs.c",
-                        "value": "NM_013275.6:c.5712_5713insT"
-                    },
-                    {
-                        "syntax": "hgvs.g",
-                        "value": "NC_000016.10:g.89280829_89280830insA"
-                    }
-                    ],
-                    "vcfRecord": {
-                    "genomeAssembly": "hg38",
-                    "chrom": "chr16",
-                    "pos": "89280829",
-                    "ref": "C",
-                    "alt": "CA"
-                    },
-                    "moleculeContext": "genomic",
-                    "allelicState": {
-                    "id": "GENO:0000135",
-                    "label": "heterozygous"
-                    }
-                }
-                }
-            }
+{
+  "subjectOrBiosampleId": "Gnazzo, 2020_P23",
+  "interpretationStatus": "CAUSATIVE",
+  "variantInterpretation": {
+    "variationDescriptor": {
+      "geneContext": {
+        "valueId": "HGNC:21316",
+        "symbol": "ANKRD11"
+      },
+      "expressions": [
+        {
+          "syntax": "hgvs.c",
+          "value": "NM_013275.6:c.5712_5713insT"
+        },
+        {
+          "syntax": "hgvs.g",
+          "value": "NC_000016.10:g.89280829_89280830insA"
+        }
+      ],
+      "vcfRecord": {
+        "genomeAssembly": "hg38",
+        "chrom": "chr16",
+        "pos": "89280829",
+        "ref": "C",
+        "alt": "CA"
+      },
+      "moleculeContext": "genomic",
+      "allelicState": {
+        "id": "GENO:0000135",
+        "label": "heterozygous"
+      }
+    }
+  }
+}

--- a/src/genophenocorr/preprocessing/test_data/missense_hgvs_test.json
+++ b/src/genophenocorr/preprocessing/test_data/missense_hgvs_test.json
@@ -17,13 +17,6 @@
           "value": "NC_000016.10:g.89279135G>C"
         }
       ],
-      "vcfRecord": {
-        "genomeAssembly": "hg38",
-        "chrom": "chr16",
-        "pos": "89279135",
-        "ref": "G",
-        "alt": "C"
-      },
       "moleculeContext": "genomic",
       "allelicState": {
         "id": "GENO:0000135",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+# content of conftest.py
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runonline", action="store_true", default=False, help="run online tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "online: mark test that require internet access to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runonline"):
+        # --runonline given in cli: do not skip online tests
+        return
+    skip_online = pytest.mark.skip(reason="need --runonline option to run")
+    for item in items:
+        if "online" in item.keywords:
+            item.add_marker(skip_online)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,24 @@
+import hpotk
+import pytest
+
+
+from genophenocorr.preprocessing import PhenopacketPatientCreator
+from genophenocorr.preprocessing import configure_patient_creator, load_phenopacket
+
+
+class TestPhenopacketPatientCreator:
+
+    @pytest.fixture
+    def hpo(self) -> hpotk.MinimalOntology:
+        return hpotk.load_minimal_ontology('testingDefaults/hp.json')
+
+    @pytest.fixture
+    def phenopacket_patient_creator(self, hpo: hpotk.MinimalOntology) -> PhenopacketPatientCreator:
+        return configure_patient_creator(hpo)
+
+    @pytest.mark.skip('Skipping online test')
+    def test_load_phenopacket(self, phenopacket_patient_creator: PhenopacketPatientCreator):
+        pp = load_phenopacket('../docs/data/simple_cohort/PMID_36446582_KBG12.json')
+        patient = phenopacket_patient_creator.create_patient(pp)
+        print(patient)
+


### PR DESCRIPTION
Fix #93 

The PR fixes a bug in change length calculation, removes trimming of the end coordinate before sending out to VEP for annotation, and prettifies the `GenomicInterpretation` JSON snippets.

Moreover, a documentation section regarding tests is added. From now on, we have 2 kinds of test, online and offline. The _online_ tests must be marked by `@pytest.mark.online` to not run them in standard CI due to spurious failures. In the long run, we should remove the online tests altogether and use mocks instead. The _offline_ tests are just the regular tests.