### PR TITLE
Used tqdm to create a progress bar

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = [
     "requests>=2.25.0",
     "scipy>=1.10",
     "statsmodels>=0.13.0",
-    "numpy>=1.23"
+    "numpy>=1.23",
+    "tqdm>=4.66.1"
 ]
 dynamic = ["version"]
 

--- a/src/genophenocorr/preprocessing/_phenopacket.py
+++ b/src/genophenocorr/preprocessing/_phenopacket.py
@@ -7,6 +7,7 @@ import hpotk
 # pyright: reportGeneralTypeIssues=false
 from google.protobuf.json_format import Parse
 from phenopackets import GenomicInterpretation, Phenopacket
+from tqdm import tqdm
 
 from genophenocorr.model import Phenotype, ProteinMetadata, VariantCoordinates, Variant, Genotype, Genotypes
 from genophenocorr.model import Patient, Cohort
@@ -245,7 +246,9 @@ def load_phenopacket_folder(pp_directory: str,
         raise ValueError(f"No JSON Phenopackets were found in {pp_directory}")
 
     # turn phenopackets into patients using patient creator
-    patients = [patient_creator.create_patient(pp) for pp in pps]
+    patients = []
+    for pp in tqdm(pps):
+        patients.append(patient_creator.create_patient(pp))
 
     # create cohort from patients
     return Cohort.from_patients(patients, include_patients_with_no_HPO)


### PR DESCRIPTION
closes #72 

Creates a progress bar that will show how many patients have been completed out of how many total when running load_phenopacket_folder. Looks better when the PR Error messages is merged as well, print statements throw off the look of the bar, but can be pushed before that PR. 