### PR TITLE
Restore the deleted `test_data_dir` fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,11 @@ def protein_test_service() -> ProteinTestMetadataService:
 
 
 @pytest.fixture(scope='session')
+def fpath_test_data_dir() -> str:
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
+
+
+@pytest.fixture(scope='session')
 def fpath_suox_cohort(
         fpath_test_data_dir: str,
 ) -> str:


### PR DESCRIPTION
Restore the `test_data` fixture that was incorrectly deleted.