### PR TITLE
Fix bug in validation of terms to test in "specify terms" MTC strategy

### DIFF
--- a/src/genophenocorr/analysis/_config.py
+++ b/src/genophenocorr/analysis/_config.py
@@ -323,7 +323,7 @@ def _validate_terms_to_test(
     for term in terms_to_test:
         if isinstance(term, hpotk.TermId):
             pass
-        if isinstance(term, str):
+        elif isinstance(term, str):
             term = hpotk.TermId.from_curie(term)
         else:
             raise ValueError(f'{term} is neither a TermId nor a CURIE `str`!')


### PR DESCRIPTION
Fix bug where input validation fails due to using sequential `if/else` instead of what should have been `if/elif/else`

Fixes #188