### PR TITLE
Fixing "Division by 0" error

### DIFF
--- a/src/genophenocorr/analysis/_gp_analysis.py
+++ b/src/genophenocorr/analysis/_gp_analysis.py
@@ -499,6 +499,11 @@ class FisherExactAnalyzer(typing.Generic[P], GPAnalyzer[P]):
 
         # 1.5) Filter terms for MTC
         n_usable, all_counts, reason2count = self._hpo_mtc_filter.filter_terms_to_test(n_usable, all_counts)
+        if len(n_usable) == 0:
+            raise ValueError(
+                f"No patients could be found to be usable for the analysis. Please verify that there is at least one patient that has a " \
+                    f"{gt_predicate.get_question()}."
+            )
 
         # 2) Statistical tests
         pheno_idx = pd.Index(n_usable.keys(), name='p_val')

--- a/src/genophenocorr/model/_variant.py
+++ b/src/genophenocorr/model/_variant.py
@@ -807,12 +807,15 @@ class Variant(VariantInfoAware, FunctionalAnnotationAware, Genotyped):
         exons_effected: typing.Sequence[int],
         protein_id: typing.Optional[str],
         hgvsp: typing.Optional[str],
-        protein_effect_start: int,
-        protein_effect_end: int,
+        protein_effect_start: typing.Optional[int],
+        protein_effect_end: typing.Optional[int],
         genotypes: Genotypes,
     ):
         variant_info = VariantInfo(variant_coordinates=variant_coordinates)
-        protein_effect = Region(protein_effect_start, protein_effect_end)
+        if protein_effect_start is not None and protein_effect_end is not None:
+            protein_effect = Region(protein_effect_start, protein_effect_end)
+        else:
+            protein_effect = None
         transcript = TranscriptAnnotation(gene_name, trans_id, hgvs_cdna, is_preferred, consequences, exons_effected,
                                           protein_id, hgvsp, protein_effect)
         return Variant(variant_info, (transcript,), genotypes)

--- a/tests/analysis/conftest.py
+++ b/tests/analysis/conftest.py
@@ -1,0 +1,109 @@
+import pytest
+
+import hpotk
+
+from genophenocorr.model import *
+from genophenocorr.model.genome import *
+from genophenocorr.analysis.predicate.genotype import VariantPredicate
+
+
+class AlwaysFalseVariantPredicate(VariantPredicate):
+    def get_question(self) -> str:
+        return "No question asked, just always returns False"
+
+    def test(self, variant: Variant) -> bool:
+        return False
+
+
+@pytest.fixture(scope="package")
+def always_false_variant_predicate() -> VariantPredicate:
+    return AlwaysFalseVariantPredicate()
+
+
+@pytest.fixture(scope="package")
+def degenerated_cohort(
+    genome_build: GenomeBuild,
+) -> Cohort:
+    """
+    This cohort is "degenerated" because the members are annotated
+    with unspecific HPO terms - just *Phenotypic abnormality*.
+    """
+    chr_22 = genome_build.contig_by_name("22")
+    assert chr_22 is not None
+    labels_a = SampleLabels("A")
+    labels_b = SampleLabels("B")
+
+    return Cohort.from_patients(
+        members=(
+            Patient(
+                labels=labels_a,
+                phenotypes=(
+                    Phenotype(
+                        term_id=hpotk.TermId.from_curie("HP:0000118"),
+                        name="Phenotypic abnormality",
+                        is_observed=True,
+                    ),
+                ),
+                diseases=(),
+                variants=(
+                    Variant.create_variant_from_scratch(
+                        VariantCoordinates.from_vcf_literal(
+                            chr_22,
+                            1001,
+                            "C",
+                            "G",
+                        ),
+                        "FAKE_GENE",
+                        "NM_123.4",
+                        hgvs_cdna="c.123C>G",
+                        is_preferred=True,
+                        consequences=(VariantEffect.MISSENSE_VARIANT,),
+                        exons_effected=(2,),
+                        protein_id=None,
+                        hgvsp=None,
+                        protein_effect_start=None,
+                        protein_effect_end=None,
+                        genotypes=Genotypes.single(
+                            sample_id=labels_a,
+                            genotype=Genotype.HETEROZYGOUS,
+                        ),
+                    ),
+                ),
+            ),
+            Patient(
+                labels=labels_b,
+                phenotypes=(
+                    Phenotype(
+                        term_id=hpotk.TermId.from_curie("HP:0000118"),
+                        name="Phenotypic abnormality",
+                        is_observed=True,
+                    ),
+                ),
+                diseases=(),
+                variants=(
+                    Variant.create_variant_from_scratch(
+                        VariantCoordinates.from_vcf_literal(
+                            chr_22,
+                            1001,
+                            "C",
+                            "G",
+                        ),
+                        "FAKE_GENE",
+                        "NM_123.4",
+                        hgvs_cdna="c.123C>G",
+                        is_preferred=True,
+                        consequences=(VariantEffect.MISSENSE_VARIANT,),
+                        exons_effected=(2,),
+                        protein_id=None,
+                        hgvsp=None,
+                        protein_effect_start=None,
+                        protein_effect_end=None,
+                        genotypes=Genotypes.single(
+                            sample_id=labels_b,
+                            genotype=Genotype.HOMOZYGOUS_ALTERNATE,
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )

--- a/tests/analysis/test_analysis.py
+++ b/tests/analysis/test_analysis.py
@@ -1,14 +1,22 @@
+import pathlib
 import typing
 
 import hpotk
 import numpy as np
 import pandas as pd
+import pytest
 
-from genophenocorr.analysis import apply_predicates_on_patients
+from genophenocorr.analysis import (
+    apply_predicates_on_patients,
+    CohortAnalysis, CohortAnalysisConfiguration,
+    configure_cohort_analysis,
+)
 
-from genophenocorr.model import Cohort
+from genophenocorr.model import *
+from genophenocorr.model.genome import *
 from genophenocorr.analysis.predicate import GenotypePolyPredicate, PatientCategories
 from genophenocorr.analysis.predicate.phenotype import PhenotypePolyPredicate
+from genophenocorr.analysis.predicate.genotype import VariantPredicate
 
 
 def test_apply_predicates_on_patients(
@@ -35,3 +43,52 @@ def test_apply_predicates_on_patients(
 
     seizure_counts = counts[hpotk.TermId.from_curie('HP:0001250')]
     assert np.array_equal(seizure_counts.to_numpy(), np.array([[17, 11], [7, 0]]))
+
+
+class TestCohortAnalysis:
+
+    @pytest.fixture
+    def cohort_analysis(
+        self,
+        suox_cohort: Cohort,
+        hpo: hpotk.MinimalOntology,
+        tmp_path: pathlib.Path,
+    ) -> CohortAnalysis:
+        return configure_cohort_analysis(
+            cohort=suox_cohort,
+            hpo=hpo,
+            cache_dir=str(tmp_path),
+        )
+
+    def test_analysis_passes_if_variant_predicate_always_returns_false(
+        self,
+        cohort_analysis: CohortAnalysis,
+        always_false_variant_predicate: VariantPredicate,
+    ):
+        results = cohort_analysis.compare_hpo_vs_genotype(
+            predicate=always_false_variant_predicate
+        )
+        assert results is not None
+
+    def test_analysis_explodes_if_no_phenotypes_are_left_for_analysis(
+        self,
+        hpo: hpotk.MinimalOntology,
+        degenerated_cohort: Cohort,
+        tmp_path: pathlib.Path,
+        always_false_variant_predicate: VariantPredicate,
+    ):
+        config = CohortAnalysisConfiguration()
+        config.heuristic_strategy()
+        cohort_analysis = configure_cohort_analysis(
+            hpo=hpo,
+            cohort=degenerated_cohort,
+            cache_dir=str(tmp_path),
+            config=config,
+        )
+
+        with pytest.raises(ValueError) as e:
+            _ = cohort_analysis.compare_hpo_vs_genotype(
+                predicate=always_false_variant_predicate,
+            )
+
+        assert e.value.args[0] == 'No phenotypes are left for the analysis after MTC filtering step'


### PR DESCRIPTION
Took me a while but figured out where I think the best spot to check for the "ZeroDivisionError: float division by zero" error that Peter got with the cohort ACBD6. 
The error occurred because no patients had the variant he was running the analysis for ("12_114385521_114385521_C_T"). A division by zero error does not accurately represent what was wrong though, so I added a test to verify that there are any usable patients before running the analysis. 

This will close #201 