### PR TITLE
`CohortViewer` needs transcript ID to visualize a cohort

### DIFF
--- a/src/gpsea/view/_viewers.py
+++ b/src/gpsea/view/_viewers.py
@@ -31,26 +31,32 @@ class CohortViewer(BaseViewer):
         """
         Args:
             hpo(MinimalOntology): An HPO ontology object from hpo-toolkit
+            tx_id(str): the transcript accession `str` (e.g. `NM_123456.7`)
             top_phenotype_count(int): Maximum number of phenotype items (HPO terms, measurements, ...) to display in the HTML table (default: 10)
             top_variant_count(int): Maximum number of variants to display in the HTML table (default: 10)
         """
         super().__init__()
+        assert isinstance(hpo, hpotk.MinimalOntology)
         self._hpo = hpo
+        assert isinstance(top_phenotype_count, int)
         self._top_phenotype_count = top_phenotype_count
+        assert isinstance(top_variant_count, int)
         self._top_variant_count = top_variant_count
         self._cohort_template = self._environment.get_template("cohort.html")
 
     def process(
         self,
         cohort: Cohort,
-        transcript_id: typing.Optional[str] = None,
+        transcript_id: str,
     ) -> GpseaReport:
         """
         Generate the report for a given `cohort`.
 
+        The variant effects will be reported with respect to the provided transcript.
+
         Args:
-            cohort (Cohort): The cohort being analyzed in the current Notebook
-            transcript_id (str): the transcript that we map variants onto
+            cohort (Cohort): the cohort to visualize
+            transcript_id (str): the accession of the target transcript (e.g. `NM_123456.7`)
 
         Returns:
             GpseaReport: a report that can be stored to a path or displayed in

--- a/tests/view/test_view.py
+++ b/tests/view/test_view.py
@@ -2,9 +2,10 @@ import math
 import os
 
 import hpotk
-import pytest
 import pandas as pd
+import pytest
 
+from gpsea.analysis import StatisticResult
 from gpsea.analysis.pcats import HpoTermAnalysisResult
 from gpsea.analysis.pcats.stats import FisherExactTest
 from gpsea.analysis.predicate.genotype import GenotypePolyPredicate
@@ -104,9 +105,9 @@ class TestMtcStatsViewer:
                     columns=pd.Index(suox_gt_predicate.get_categories()),
                 ),
             ),
-            pvals=(
-                math.nan,
-                0.005,
+            statistic_results=(
+                StatisticResult(statistic=None, pval=math.nan), 
+                StatisticResult(statistic=1.23, pval=0.01), 
             ),
             corrected_pvals=(math.nan, 0.01),
             mtc_filter_name="Random MTC filter",


### PR DESCRIPTION
Require a transcript id to visualize a cohort in the  `CohortViewer`.

Fixes #365