### PR TITLE
Do not install and test before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,6 @@ jobs:
               uses: actions/setup-python@v5
               with:
                   python-version: "3.12"
-            - name: Install the package
-              run: python -m pip install --editable .[test]
-            - name: Run tests
-              run: pytest
             - name: Install build libraries
               run: python3 -m pip install build
             - name: Build package


### PR DESCRIPTION
No need to test during the release action, we already must have tested in the CI.